### PR TITLE
feat: initialise the weights and biases

### DIFF
--- a/NeuralNetworks/dnn.py
+++ b/NeuralNetworks/dnn.py
@@ -56,8 +56,35 @@ class DeepNeuralNetwork:
         weights = np.random.randn(size, num_inputs) * np.sqrt(2 / num_inputs)
         return tf.Variable(weights, dtype=tf.float32)
     
+    """
+    DNN weights are initialised using the He initialisation method.
+    DNN biases are initialised to be 0. 
+
+    Parameters:
+        n (int): number of neurons in the layer
+        layer_size (int): number of layers in the DNN
+
+    Returns:
+        p (list): initialised DNN parameters
+    """
     def initialise_weights(self, n, layer_size):
-        pass
+        weights_matrices = []
+        biases_vectors = []
+
+        weights_matrices.append(self.initialise_he([n, 1], 1))
+        biases_vectors.append(tf.Variable(np.zeros(n, 1), dtype=tf.float32))
+
+        for i in range(layer_size - 2):
+            weights_matrices.append(self.initialise_he([n, n], n))
+            biases_vectors.append(tf.Variable(np.zeros(n, 1), dtype=tf.float32))
+
+        weights_matrices.append(self.initialise_he([1, n], n))
+        biases_vectors.append(tf.Variable(np.zeros(1, 1), dtype=tf.float32))
+
+        for weights_matrix, biases_vector in zip(weights_matrices, biases_vectors):
+            p.append({'weights': weights_matrix, 'biases': biases_vector})
+
+        return p
 
     """
     Initialise the iteration count, average gradient and average squared gradient.


### PR DESCRIPTION
Through weight initialization, we can prevent layer activation outputs from exploding or vanishing gradients during the forward propagation. 