### PR TITLE
refactor: use standard normal distribution

### DIFF
--- a/NeuralNetworks/dnn.py
+++ b/NeuralNetworks/dnn.py
@@ -53,8 +53,8 @@ class DeepNeuralNetwork:
         weights (tf.Variable): initialised weights
     """
     def initialise_he(self, size, num_inputs):
-        weights = tf.random.truncated_normal(size, stddev=tf.sqrt(2/num_inputs))
-        return tf.convert_to_tensors(weights, dtype=tf.float32)
+        weights = tf.random.normal(size, stddev=tf.sqrt(2/num_inputs))
+        return tf.convert_to_tensor(weights, dtype=tf.float32)
     
     def initialise_weights(self, n, layer_size):
         pass


### PR DESCRIPTION
`initialise_he` function generates random numbers from a truncated normal distribution, which means that the numbers are more likely to be near the mean of the distribution. However, for He initialization, standard normal distribution should be used which will generate random numbers with a wider range of values.